### PR TITLE
fix: handle empty and edge case inputs in byte-level AES modes

### DIFF
--- a/python_aes/aes256.py
+++ b/python_aes/aes256.py
@@ -173,7 +173,8 @@ class AESBytesECB(AESBase):
         async with aiofiles.open(output_file, mode="wb") as fout:
             for block in blocks[:-1]:
                 await fout.write(block_to_byte(block))
-            await fout.write(block_to_byte(remove_trailing_zero(blocks[-1])))
+            if blocks:
+                await fout.write(block_to_byte(remove_trailing_zero(blocks[-1])))
 
 
 class AESBytesCBC(AESBase):
@@ -196,7 +197,10 @@ class AESBytesCBC(AESBase):
                     await fout.write(block_to_byte(next_decrypted_block))
                 next_decrypted_block = dec_block
                 previous_block = block
-            await fout.write(block_to_byte(remove_trailing_zero(next_decrypted_block)))
+            if next_decrypted_block is not None:
+                await fout.write(
+                    block_to_byte(remove_trailing_zero(next_decrypted_block))
+                )
 
 
 def add_roundkey(round_key: List[int], block: List[int]) -> Iterable[int]:

--- a/python_aes/aes_ctr_mode.py
+++ b/python_aes/aes_ctr_mode.py
@@ -84,8 +84,9 @@ class ByteCounterMode(CounterMode):
                 if _buffer:
                     fout.write(block_to_byte(_buffer))
                 _buffer = dec_block
-            _buffer = remove_trailing_zero(_buffer)
-            fout.write(block_to_byte(_buffer))
+            if _buffer is not None:
+                _buffer = remove_trailing_zero(_buffer)
+                fout.write(block_to_byte(_buffer))
 
     async def encrypt(self, filename: str, output_file: str):
         with open(output_file, "wb") as fout:

--- a/python_aes/text_to_number_conversion.py
+++ b/python_aes/text_to_number_conversion.py
@@ -136,7 +136,7 @@ def chunks(blocks: Sequence, n: int = 16) -> Generator[Sequence, Any, None]:
 
 
 def rstrip_value(value: Any, my_list: List[Any]) -> List[Any]:
-    while my_list[-1] == value:
+    while my_list and my_list[-1] == value:
         my_list.pop(-1)
     return my_list
 

--- a/tests/integration/test_aes_interface.py
+++ b/tests/integration/test_aes_interface.py
@@ -53,3 +53,47 @@ async def test_aes_string_non_aligned(default_hex_key):
     enc = "".join(my_aes.encrypt(text))
     dec_string = "".join(my_aes.decrypt(enc))
     assert dec_string == text
+
+
+async def test_aes_bytes_ecb_empty_file(default_hex_key, tmp_path):
+    data_file = tmp_path / "empty.txt"
+    data_file.write_text("")
+    my_aes = AESBytesECB(key=default_hex_key)
+    enc_file = tmp_path / "enc.bin"
+    dec_file = tmp_path / "dec.bin"
+    await my_aes.encrypt(filename=str(data_file), output_file=str(enc_file))
+    await my_aes.decrypt(filename=str(enc_file), output_file=str(dec_file))
+    assert filecmp.cmp(str(data_file), str(dec_file)) is True
+
+
+async def test_aes_bytes_ecb_single_block(default_hex_key, tmp_path):
+    data_file = tmp_path / "single_block.txt"
+    data_file.write_bytes(b"A" * 16)
+    my_aes = AESBytesECB(key=default_hex_key)
+    enc_file = tmp_path / "enc.bin"
+    dec_file = tmp_path / "dec.bin"
+    await my_aes.encrypt(filename=str(data_file), output_file=str(enc_file))
+    await my_aes.decrypt(filename=str(enc_file), output_file=str(dec_file))
+    assert filecmp.cmp(str(data_file), str(dec_file)) is True
+
+
+async def test_aes_bytes_cbc_empty_file(default_hex_key, tmp_path):
+    data_file = tmp_path / "empty.txt"
+    data_file.write_text("")
+    my_aes = AESBytesCBC(key=default_hex_key)
+    enc_file = tmp_path / "enc.bin"
+    dec_file = tmp_path / "dec.bin"
+    await my_aes.encrypt(filename=str(data_file), output_file=str(enc_file))
+    await my_aes.decrypt(filename=str(enc_file), output_file=str(dec_file))
+    assert filecmp.cmp(str(data_file), str(dec_file)) is True
+
+
+async def test_aes_bytes_cbc_single_block(default_hex_key, tmp_path):
+    data_file = tmp_path / "single_block.txt"
+    data_file.write_bytes(b"B" * 16)
+    my_aes = AESBytesCBC(key=default_hex_key)
+    enc_file = tmp_path / "enc.bin"
+    dec_file = tmp_path / "dec.bin"
+    await my_aes.encrypt(filename=str(data_file), output_file=str(enc_file))
+    await my_aes.decrypt(filename=str(enc_file), output_file=str(dec_file))
+    assert filecmp.cmp(str(data_file), str(dec_file)) is True

--- a/tests/integration/test_ctr_mode.py
+++ b/tests/integration/test_ctr_mode.py
@@ -52,3 +52,39 @@ def test_ctr_mode_string_non_aligned(hex_key):
     enc_blocks = list(my_aes.encrypt(text))
     dec = "".join(my_aes.decrypt(enc_blocks))
     assert dec == text
+
+
+async def test_ctr_mode_bytes_empty(default_hex_key, tmp_path):
+    data_file = tmp_path / "empty.bin"
+    data_file.write_bytes(b"")
+    my_aes = ByteCounterMode(key=default_hex_key, block_size=DEFAULT_BLOCK_SIZE)
+    my_aes.set_nonce(sample_nonce(8))
+    enc_file = tmp_path / "enc.bin"
+    dec_file = tmp_path / "dec.bin"
+    await my_aes.encrypt(filename=str(data_file), output_file=str(enc_file))
+    await my_aes.decrypt(filename=str(enc_file), output_file=str(dec_file))
+    assert filecmp.cmp(str(data_file), str(dec_file)) is True
+
+
+async def test_ctr_mode_bytes_single_block(default_hex_key, tmp_path):
+    data_file = tmp_path / "single.bin"
+    data_file.write_bytes(b"X" * DEFAULT_BLOCK_SIZE)
+    my_aes = ByteCounterMode(key=default_hex_key, block_size=DEFAULT_BLOCK_SIZE)
+    my_aes.set_nonce(sample_nonce(8))
+    enc_file = tmp_path / "enc.bin"
+    dec_file = tmp_path / "dec.bin"
+    await my_aes.encrypt(filename=str(data_file), output_file=str(enc_file))
+    await my_aes.decrypt(filename=str(enc_file), output_file=str(dec_file))
+    assert filecmp.cmp(str(data_file), str(dec_file)) is True
+
+
+async def test_ctr_mode_bytes_binary_data(default_hex_key, tmp_path):
+    data_file = tmp_path / "binary.bin"
+    data_file.write_bytes(bytes(range(256)))
+    my_aes = ByteCounterMode(key=default_hex_key, block_size=DEFAULT_BLOCK_SIZE)
+    my_aes.set_nonce(sample_nonce(8))
+    enc_file = tmp_path / "enc.bin"
+    dec_file = tmp_path / "dec.bin"
+    await my_aes.encrypt(filename=str(data_file), output_file=str(enc_file))
+    await my_aes.decrypt(filename=str(enc_file), output_file=str(dec_file))
+    assert filecmp.cmp(str(data_file), str(dec_file)) is True


### PR DESCRIPTION
- Fix rstrip_value to guard against empty lists (IndexError)
- Fix AESBytesECB.decrypt to handle empty blocks
- Fix AESBytesCBC.decrypt to handle None next_decrypted_block
- Fix ByteCounterMode.decrypt to handle None _buffer
- Add edge case tests: empty files, single block, binary data